### PR TITLE
set correct dependentCount

### DIFF
--- a/src/account/BaseModularAccount.sol
+++ b/src/account/BaseModularAccount.sol
@@ -207,7 +207,8 @@ abstract contract BaseModularAccount is IPluginManager, AccountExecutor, IERC165
     {
         bytes24 key = getPermittedCallKey(plugin, selector);
 
-        if (accountStorage.selectorData[selector].plugin == address(0)) {
+        address execPlugin = accountStorage.selectorData[selector].plugin;
+        if (execPlugin == address(0)) {
             revert PermittedExecutionSelectorNotInstalled(selector, plugin);
         }
 
@@ -215,16 +216,21 @@ abstract contract BaseModularAccount is IPluginManager, AccountExecutor, IERC165
             revert ExecuteFromPluginAlreadySet(selector, plugin);
         }
         accountStorage.permittedCalls[key].callPermitted = true;
+        accountStorage.pluginData[execPlugin].dependentCount += 1;
     }
 
     function _disableExecFromPlugin(bytes4 selector, address plugin, AccountStorage storage accountStorage)
         internal
     {
         bytes24 key = getPermittedCallKey(plugin, selector);
+
+        address execPlugin = accountStorage.selectorData[selector].plugin;
+
         if (!accountStorage.permittedCalls[key].callPermitted) {
             revert ExecuteFromPluginNotSet(selector, plugin);
         }
         accountStorage.permittedCalls[key].callPermitted = false;
+        accountStorage.pluginData[execPlugin].dependentCount -= 1;
     }
 
     function _addPermittedCallHooks(


### PR DESCRIPTION
## Motivation
`dependentCount` in `pluginData` of plugin A is to record how many other plugins depends on plugin A.
If we want to uninstall plugin A, we have to make sure its `dependentCount` equals to 0.
When installing plugin B, we should also increase the  `dependentCount` of the installed plugins responsible for `permittedExecutionSelectors`. Otherwise, after uninstalling those plugins, the plugin B will be broken.

## Solution
Increase `dependentCount` in `_enableExecFromPlugin` and decrease `dependentCount` in `_disableExecFromPlugin`.
