### PR TITLE
Remove extraneous install/uninstall field checking

### DIFF
--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -296,7 +296,7 @@ contract UpgradeableModularAccountTest is Test {
         assertEq(plugins[1], address(tokenReceiverPlugin));
     }
 
-    function test_installPlugin_ExecuteFromPlugin_BadPermittedExecSelector() public {
+    function test_installPlugin_ExecuteFromPlugin_PermittedExecSelectorNotInstalled() public {
         vm.startPrank(owner2);
 
         PluginManifest memory m;
@@ -306,13 +306,6 @@ contract UpgradeableModularAccountTest is Test {
         MockPlugin mockPluginWithBadPermittedExec = new MockPlugin(m);
         bytes32 manifestHash = keccak256(abi.encode(mockPluginWithBadPermittedExec.pluginManifest()));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                PluginManagerInternals.PermittedExecutionSelectorNotInstalled.selector,
-                IPlugin.onInstall.selector,
-                address(mockPluginWithBadPermittedExec)
-            )
-        );
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginWithBadPermittedExec),
             manifestHash: manifestHash,
@@ -590,7 +583,7 @@ contract UpgradeableModularAccountTest is Test {
     }
 
     function test_injectHooksUninstall() external {
-        (, MockPlugin newPlugin, bytes32 manifestHash) = _installWithInjectHooks();
+        (, MockPlugin newPlugin,) = _installWithInjectHooks();
 
         vm.expectEmit(true, true, true, true);
         emit PluginUninstalled(address(newPlugin), true);


### PR DESCRIPTION
## Motivation

There is a large amount of extraneous checks in plugin installation and uninstallation that are not required by the ERC-6900 standard.

## Solution

- Remove checks during `uninstallPlugin` that assert the values to be the same as what was used during installation. Because the manifest hash is validated prior to the individual field removals, we know that all fields must have been successfully added.
   - The only way this invariant may be violated is if the account is upgraded to a custom implementation then upgraded back to this implementation. In such a case, the behavior is undefined.
- Remove the strict requirement that `permittedExecutionSelectors` must be installed. Due to the possibility that other hooks may cause the call to `executeFromPlugin` to fail, plugins must already expect this possibility, and a lack of installation results in a similar call revert.
   - This also makes dependency management and plugin upgrading slightly easier.
- Remove all of the now-unused custom errors.

This PR is stacked on top of #13, and should only be merged after the underlying is merged.