### PR TITLE
Split up base account to fit under size limit

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,6 @@ libs = ['lib']
 out = 'out'
 optimizer = true
 optimizer_runs = 10_000
-ignored_error_codes = [3628]
 fs_permissions = [
   { access = "read", path = "./out-optimized" }
 ]

--- a/src/account/PluginManager.sol
+++ b/src/account/PluginManager.sol
@@ -27,9 +27,11 @@ import {
     PluginManifest
 } from "../interfaces/IPlugin.sol";
 
-abstract contract PluginManager is IPluginManager {
+contract PluginManager {
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
     using EnumerableSet for EnumerableSet.AddressSet;
+
+    address private immutable _SELF;
 
     error ArrayLengthMismatch();
     error ExecutionFunctionAlreadySet(bytes4 selector);
@@ -38,6 +40,7 @@ abstract contract PluginManager is IPluginManager {
     error MissingPluginDependency(address dependency);
     error NullFunctionReference();
     error NullPlugin();
+    error OnlyDelegate();
     error PluginAlreadyInstalled(address plugin);
     error PluginDependencyViolation(address plugin);
     error PluginInstallCallbackFailed(address plugin, bytes revertReason);
@@ -47,6 +50,17 @@ abstract contract PluginManager is IPluginManager {
     error UserOpValidationFunctionAlreadySet(bytes4 selector, FunctionReference validationFunction);
     error PluginApplyHookCallbackFailed(address providingPlugin, bytes revertReason);
     error PluginUnapplyHookCallbackFailed(address providingPlugin, bytes revertReason);
+
+    // Re-declare events from IPluginManager, since solidity doesn't support importing events from interfaces.
+
+    event PluginInstalled(
+        address indexed plugin,
+        bytes32 manifestHash,
+        FunctionReference[] dependencies,
+        IPluginManager.InjectedHook[] injectedHooks
+    );
+
+    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
 
     modifier notNullFunction(FunctionReference functionReference) {
         if (functionReference.isEmpty()) {
@@ -62,210 +76,24 @@ abstract contract PluginManager is IPluginManager {
         _;
     }
 
-    // Storage update operations
-
-    function _setExecutionFunction(bytes4 selector, address plugin) internal notNullPlugin(plugin) {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        if (_selectorData.plugin != address(0)) {
-            revert ExecutionFunctionAlreadySet(selector);
+    modifier onlyDelegate() {
+        if (address(this) == _SELF) {
+            revert OnlyDelegate();
         }
-
-        _selectorData.plugin = plugin;
+        _;
     }
 
-    function _removeExecutionFunction(bytes4 selector) internal {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _selectorData.plugin = address(0);
+    constructor() {
+        _SELF = address(this);
     }
 
-    function _addUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        if (!_selectorData.userOpValidation.isEmpty()) {
-            revert UserOpValidationFunctionAlreadySet(selector, validationFunction);
-        }
-
-        _selectorData.userOpValidation = validationFunction;
-    }
-
-    function _removeUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _selectorData.userOpValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
-    }
-
-    function _addRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        if (!_selectorData.runtimeValidation.isEmpty()) {
-            revert RuntimeValidationFunctionAlreadySet(selector, validationFunction);
-        }
-
-        _selectorData.runtimeValidation = validationFunction;
-    }
-
-    function _removeRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
-        internal
-        notNullFunction(validationFunction)
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _selectorData.runtimeValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
-    }
-
-    function _addExecHooks(bytes4 selector, FunctionReference preExecHook, FunctionReference postExecHook)
-        internal
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _addHooks(_selectorData.executionHooks, preExecHook, postExecHook);
-    }
-
-    function _removeExecHooks(bytes4 selector, FunctionReference preExecHook, FunctionReference postExecHook)
-        internal
-    {
-        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
-
-        _removeHooks(_selectorData.executionHooks, preExecHook, postExecHook);
-    }
-
-    function _enableExecFromPlugin(bytes4 selector, address plugin, AccountStorage storage accountStorage)
-        internal
-    {
-        bytes24 key = getPermittedCallKey(plugin, selector);
-
-        // If there are duplicates, this will just enable the flag again. This is not a problem, since the boolean
-        // will be set to false twice during uninstall, which is fine.
-        accountStorage.permittedCalls[key].callPermitted = true;
-    }
-
-    function _disableExecFromPlugin(bytes4 selector, address plugin, AccountStorage storage accountStorage)
-        internal
-    {
-        bytes24 key = getPermittedCallKey(plugin, selector);
-        accountStorage.permittedCalls[key].callPermitted = false;
-    }
-
-    function _addPermittedCallHooks(
-        bytes4 selector,
-        address plugin,
-        FunctionReference preExecHook,
-        FunctionReference postExecHook
-    ) internal notNullPlugin(plugin) {
-        bytes24 permittedCallKey = getPermittedCallKey(plugin, selector);
-        PermittedCallData storage _permittedCalldata = getAccountStorage().permittedCalls[permittedCallKey];
-
-        _addHooks(_permittedCalldata.permittedCallHooks, preExecHook, postExecHook);
-    }
-
-    function _removePermittedCallHooks(
-        bytes4 selector,
-        address plugin,
-        FunctionReference preExecHook,
-        FunctionReference postExecHook
-    ) internal notNullPlugin(plugin) {
-        bytes24 permittedCallKey = getPermittedCallKey(plugin, selector);
-        PermittedCallData storage _permittedCallData = getAccountStorage().permittedCalls[permittedCallKey];
-
-        _removeHooks(_permittedCallData.permittedCallHooks, preExecHook, postExecHook);
-    }
-
-    function _addHooks(HookGroup storage hooks, FunctionReference preExecHook, FunctionReference postExecHook)
-        internal
-    {
-        if (!preExecHook.isEmpty()) {
-            _addOrIncrement(hooks.preHooks, _toSetValue(preExecHook));
-
-            if (!postExecHook.isEmpty()) {
-                _addOrIncrement(hooks.associatedPostHooks[preExecHook], _toSetValue(postExecHook));
-            }
-        } else {
-            if (postExecHook.isEmpty()) {
-                // both pre and post hooks cannot be null
-                revert NullFunctionReference();
-            }
-
-            _addOrIncrement(hooks.postOnlyHooks, _toSetValue(postExecHook));
-        }
-    }
-
-    function _removeHooks(HookGroup storage hooks, FunctionReference preExecHook, FunctionReference postExecHook)
-        internal
-    {
-        if (!preExecHook.isEmpty()) {
-            _removeOrDecrement(hooks.preHooks, _toSetValue(preExecHook));
-
-            if (!postExecHook.isEmpty()) {
-                _removeOrDecrement(hooks.associatedPostHooks[preExecHook], _toSetValue(postExecHook));
-            }
-        } else {
-            // The case where both pre and post hooks are null was checked during installation.
-
-            // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
-            _removeOrDecrement(hooks.postOnlyHooks, _toSetValue(postExecHook));
-        }
-    }
-
-    function _addPreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
-        internal
-        notNullFunction(preUserOpValidationHook)
-    {
-        _addOrIncrement(
-            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
-            _toSetValue(preUserOpValidationHook)
-        );
-    }
-
-    function _removePreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
-        internal
-        notNullFunction(preUserOpValidationHook)
-    {
-        // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
-        _removeOrDecrement(
-            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
-            _toSetValue(preUserOpValidationHook)
-        );
-    }
-
-    function _addPreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
-        internal
-        notNullFunction(preRuntimeValidationHook)
-    {
-        _addOrIncrement(
-            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
-            _toSetValue(preRuntimeValidationHook)
-        );
-    }
-
-    function _removePreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
-        internal
-        notNullFunction(preRuntimeValidationHook)
-    {
-        // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
-        _removeOrDecrement(
-            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
-            _toSetValue(preRuntimeValidationHook)
-        );
-    }
-
-    function _installPlugin(
+    function installPlugin(
         address plugin,
         bytes32 manifestHash,
         bytes memory pluginInitData,
         FunctionReference[] memory dependencies,
-        InjectedHook[] memory injectedHooks
-    ) internal {
+        IPluginManager.InjectedHook[] memory injectedHooks
+    ) external onlyDelegate {
         AccountStorage storage _storage = getAccountStorage();
 
         // Check if the plugin exists.
@@ -384,7 +212,7 @@ abstract contract PluginManager is IPluginManager {
         }
 
         for (uint256 i = 0; i < length;) {
-            InjectedHook memory hook = injectedHooks[i];
+            IPluginManager.InjectedHook memory hook = injectedHooks[i];
             _storage.pluginData[plugin].injectedHooks[i] = StoredInjectedHook({
                 providingPlugin: hook.providingPlugin,
                 selector: hook.selector,
@@ -536,7 +364,7 @@ abstract contract PluginManager is IPluginManager {
         length = injectedHooks.length;
 
         for (uint256 i = 0; i < length;) {
-            InjectedHook memory hook = injectedHooks[i];
+            IPluginManager.InjectedHook memory hook = injectedHooks[i];
             // not inlined in function call to avoid stack too deep error
             bytes memory onHookApplyData = injectedHooks[i].hookApplyData;
             /* solhint-disable no-empty-blocks */
@@ -560,12 +388,12 @@ abstract contract PluginManager is IPluginManager {
         emit PluginInstalled(plugin, manifestHash, dependencies, injectedHooks);
     }
 
-    function _uninstallPlugin(
+    function uninstallPlugin(
         address plugin,
         PluginManifest memory manifest,
         bytes memory uninstallData,
         bytes[] calldata hookUnapplyData
-    ) internal {
+    ) external onlyDelegate {
         AccountStorage storage _storage = getAccountStorage();
 
         // Check if the plugin exists.
@@ -808,7 +636,7 @@ abstract contract PluginManager is IPluginManager {
             /* solhint-disable no-empty-blocks */
             try IPlugin(hook.providingPlugin).onHookUnapply(
                 plugin,
-                InjectedHooksInfo({
+                IPluginManager.InjectedHooksInfo({
                     preExecHookFunctionId: hook.preExecHookFunctionId,
                     isPostHookUsed: hook.isPostHookUsed,
                     postExecHookFunctionId: hook.postExecHookFunctionId
@@ -836,6 +664,203 @@ abstract contract PluginManager is IPluginManager {
         }
 
         emit PluginUninstalled(plugin, onUninstallSuccess);
+    }
+
+    // Storage update operations
+
+    function _setExecutionFunction(bytes4 selector, address plugin) internal notNullPlugin(plugin) {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        if (_selectorData.plugin != address(0)) {
+            revert ExecutionFunctionAlreadySet(selector);
+        }
+
+        _selectorData.plugin = plugin;
+    }
+
+    function _removeExecutionFunction(bytes4 selector) internal {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        _selectorData.plugin = address(0);
+    }
+
+    function _addUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
+        internal
+        notNullFunction(validationFunction)
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        if (!_selectorData.userOpValidation.isEmpty()) {
+            revert UserOpValidationFunctionAlreadySet(selector, validationFunction);
+        }
+
+        _selectorData.userOpValidation = validationFunction;
+    }
+
+    function _removeUserOpValidationFunction(bytes4 selector, FunctionReference validationFunction)
+        internal
+        notNullFunction(validationFunction)
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        _selectorData.userOpValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
+    }
+
+    function _addRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
+        internal
+        notNullFunction(validationFunction)
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        if (!_selectorData.runtimeValidation.isEmpty()) {
+            revert RuntimeValidationFunctionAlreadySet(selector, validationFunction);
+        }
+
+        _selectorData.runtimeValidation = validationFunction;
+    }
+
+    function _removeRuntimeValidationFunction(bytes4 selector, FunctionReference validationFunction)
+        internal
+        notNullFunction(validationFunction)
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        _selectorData.runtimeValidation = FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
+    }
+
+    function _addExecHooks(bytes4 selector, FunctionReference preExecHook, FunctionReference postExecHook)
+        internal
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        _addHooks(_selectorData.executionHooks, preExecHook, postExecHook);
+    }
+
+    function _removeExecHooks(bytes4 selector, FunctionReference preExecHook, FunctionReference postExecHook)
+        internal
+    {
+        SelectorData storage _selectorData = getAccountStorage().selectorData[selector];
+
+        _removeHooks(_selectorData.executionHooks, preExecHook, postExecHook);
+    }
+
+    function _enableExecFromPlugin(bytes4 selector, address plugin, AccountStorage storage accountStorage)
+        internal
+    {
+        bytes24 key = getPermittedCallKey(plugin, selector);
+
+        // If there are duplicates, this will just enable the flag again. This is not a problem, since the boolean
+        // will be set to false twice during uninstall, which is fine.
+        accountStorage.permittedCalls[key].callPermitted = true;
+    }
+
+    function _disableExecFromPlugin(bytes4 selector, address plugin, AccountStorage storage accountStorage)
+        internal
+    {
+        bytes24 key = getPermittedCallKey(plugin, selector);
+        accountStorage.permittedCalls[key].callPermitted = false;
+    }
+
+    function _addPermittedCallHooks(
+        bytes4 selector,
+        address plugin,
+        FunctionReference preExecHook,
+        FunctionReference postExecHook
+    ) internal notNullPlugin(plugin) {
+        bytes24 permittedCallKey = getPermittedCallKey(plugin, selector);
+        PermittedCallData storage _permittedCalldata = getAccountStorage().permittedCalls[permittedCallKey];
+
+        _addHooks(_permittedCalldata.permittedCallHooks, preExecHook, postExecHook);
+    }
+
+    function _removePermittedCallHooks(
+        bytes4 selector,
+        address plugin,
+        FunctionReference preExecHook,
+        FunctionReference postExecHook
+    ) internal notNullPlugin(plugin) {
+        bytes24 permittedCallKey = getPermittedCallKey(plugin, selector);
+        PermittedCallData storage _permittedCallData = getAccountStorage().permittedCalls[permittedCallKey];
+
+        _removeHooks(_permittedCallData.permittedCallHooks, preExecHook, postExecHook);
+    }
+
+    function _addHooks(HookGroup storage hooks, FunctionReference preExecHook, FunctionReference postExecHook)
+        internal
+    {
+        if (!preExecHook.isEmpty()) {
+            _addOrIncrement(hooks.preHooks, _toSetValue(preExecHook));
+
+            if (!postExecHook.isEmpty()) {
+                _addOrIncrement(hooks.associatedPostHooks[preExecHook], _toSetValue(postExecHook));
+            }
+        } else {
+            if (postExecHook.isEmpty()) {
+                // both pre and post hooks cannot be null
+                revert NullFunctionReference();
+            }
+
+            _addOrIncrement(hooks.postOnlyHooks, _toSetValue(postExecHook));
+        }
+    }
+
+    function _removeHooks(HookGroup storage hooks, FunctionReference preExecHook, FunctionReference postExecHook)
+        internal
+    {
+        if (!preExecHook.isEmpty()) {
+            _removeOrDecrement(hooks.preHooks, _toSetValue(preExecHook));
+
+            if (!postExecHook.isEmpty()) {
+                _removeOrDecrement(hooks.associatedPostHooks[preExecHook], _toSetValue(postExecHook));
+            }
+        } else {
+            // The case where both pre and post hooks are null was checked during installation.
+
+            // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
+            _removeOrDecrement(hooks.postOnlyHooks, _toSetValue(postExecHook));
+        }
+    }
+
+    function _addPreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
+        internal
+        notNullFunction(preUserOpValidationHook)
+    {
+        _addOrIncrement(
+            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
+            _toSetValue(preUserOpValidationHook)
+        );
+    }
+
+    function _removePreUserOpValidationHook(bytes4 selector, FunctionReference preUserOpValidationHook)
+        internal
+        notNullFunction(preUserOpValidationHook)
+    {
+        // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
+        _removeOrDecrement(
+            getAccountStorage().selectorData[selector].preUserOpValidationHooks,
+            _toSetValue(preUserOpValidationHook)
+        );
+    }
+
+    function _addPreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
+        internal
+        notNullFunction(preRuntimeValidationHook)
+    {
+        _addOrIncrement(
+            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
+            _toSetValue(preRuntimeValidationHook)
+        );
+    }
+
+    function _removePreRuntimeValidationHook(bytes4 selector, FunctionReference preRuntimeValidationHook)
+        internal
+        notNullFunction(preRuntimeValidationHook)
+    {
+        // May ignore return value, as the manifest hash is validated to ensure that the hook exists.
+        _removeOrDecrement(
+            getAccountStorage().selectorData[selector].preRuntimeValidationHooks,
+            _toSetValue(preRuntimeValidationHook)
+        );
     }
 
     function _addOrIncrement(EnumerableMap.Bytes32ToUintMap storage map, bytes32 key) internal {

--- a/src/account/PluginManager.sol
+++ b/src/account/PluginManager.sol
@@ -27,7 +27,7 @@ import {
     PluginManifest
 } from "../interfaces/IPlugin.sol";
 
-abstract contract PluginManagerInternals is IPluginManager {
+abstract contract PluginManager is IPluginManager {
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;
     using EnumerableSet for EnumerableSet.AddressSet;
 

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -18,7 +18,7 @@ import {IPlugin, PluginManifest} from "../interfaces/IPlugin.sol";
 import {IPluginExecutor} from "../interfaces/IPluginExecutor.sol";
 import {IPluginManager} from "../interfaces/IPluginManager.sol";
 import {IStandardExecutor, Call} from "../interfaces/IStandardExecutor.sol";
-import {PluginManagerInternals} from "./PluginManagerInternals.sol";
+import {PluginManager} from "./PluginManager.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationDataHelpers.sol";
 
 contract UpgradeableModularAccount is
@@ -29,7 +29,7 @@ contract UpgradeableModularAccount is
     IERC165,
     IPluginExecutor,
     IStandardExecutor,
-    PluginManagerInternals,
+    PluginManager,
     UUPSUpgradeable
 {
     using EnumerableMap for EnumerableMap.Bytes32ToUintMap;

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -5,7 +5,7 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 
 import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
-import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
+import {PluginManager} from "../../src/account/PluginManager.sol";
 import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
@@ -46,7 +46,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -64,7 +64,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -82,7 +82,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -98,7 +98,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -114,7 +114,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -131,7 +131,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -148,7 +148,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
@@ -164,7 +164,7 @@ contract ManifestValidityTest is OptimizedTest {
 
         bytes32 manifestHash = keccak256(abi.encode(plugin.pluginManifest()));
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -7,7 +7,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 import {UserOperation} from "@eth-infinitism/account-abstraction/interfaces/UserOperation.sol";
 
-import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
+import {PluginManager} from "../../src/account/PluginManager.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {SingleOwnerPlugin} from "../../src/plugins/owner/SingleOwnerPlugin.sol";
 import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
@@ -319,7 +319,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
     function test_installPlugin_invalidManifest() public {
         vm.startPrank(owner2);
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
             manifestHash: bytes32(0),
@@ -334,7 +334,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
 
         address badPlugin = address(1);
         vm.expectRevert(
-            abi.encodeWithSelector(PluginManagerInternals.PluginInterfaceNotSupported.selector, address(badPlugin))
+            abi.encodeWithSelector(PluginManager.PluginInterfaceNotSupported.selector, address(badPlugin))
         );
         IPluginManager(account2).installPlugin({
             plugin: address(badPlugin),
@@ -358,9 +358,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
         });
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                PluginManagerInternals.PluginAlreadyInstalled.selector, address(tokenReceiverPlugin)
-            )
+            abi.encodeWithSelector(PluginManager.PluginAlreadyInstalled.selector, address(tokenReceiverPlugin))
         );
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
@@ -441,7 +439,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
         // Attempt to uninstall with a blank manifest
         PluginManifest memory blankManifest;
 
-        vm.expectRevert(abi.encodeWithSelector(PluginManagerInternals.InvalidPluginManifest.selector));
+        vm.expectRevert(abi.encodeWithSelector(PluginManager.InvalidPluginManifest.selector));
         IPluginManager(account2).uninstallPlugin({
             plugin: address(plugin),
             config: abi.encode(blankManifest),
@@ -571,7 +569,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
         );
 
         vm.expectRevert(
-            abi.encodeWithSelector(PluginManagerInternals.MissingPluginDependency.selector, address(hooksPlugin))
+            abi.encodeWithSelector(PluginManager.MissingPluginDependency.selector, address(hooksPlugin))
         );
         vm.prank(owner2);
         IPluginManager(account2).installPlugin({
@@ -602,7 +600,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
 
         vm.prank(owner2);
         vm.expectRevert(
-            abi.encodeWithSelector(PluginManagerInternals.PluginDependencyViolation.selector, address(hooksPlugin))
+            abi.encodeWithSelector(PluginManager.PluginDependencyViolation.selector, address(hooksPlugin))
         );
         IPluginManager(account2).uninstallPlugin({
             plugin: address(hooksPlugin),
@@ -638,7 +636,7 @@ contract UpgradeableModularAccountTest is OptimizedTest {
         // length != installed hooks length
         bytes[] memory injectedHooksDatas = new bytes[](2);
 
-        vm.expectRevert(PluginManagerInternals.ArrayLengthMismatch.selector);
+        vm.expectRevert(PluginManager.ArrayLengthMismatch.selector);
         vm.prank(owner2);
         IPluginManager(account2).uninstallPlugin({
             plugin: address(newPlugin),

--- a/test/mocks/MockPlugin.sol
+++ b/test/mocks/MockPlugin.sol
@@ -73,6 +73,8 @@ contract MockPlugin is ERC165 {
         return interfaceId == type(IPlugin).interfaceId || super.supportsInterface(interfaceId);
     }
 
+    receive() external payable {}
+
     // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
         emit ReceivedCall(msg.data, msg.value);


### PR DESCRIPTION
## Motivation

The contract size of `UpgradeableModularAccount` exceeds the 24.5kb size limit. While the intention behind the reference implementation is not that it should be used in production, this makes it difficult to test integrations with outside of the context of foundry tests and other forked environments.

## Solution

Split out `PluginManagerInternals` into a distinct `PluginManager` contract. `UpgradeableModularAccount` performs `delegatecall`s into this contract, much like a library. However, using a delegate-only contract over a library gives us easier integration into deployment tools like scripts.

This brings the size for both contracts under the limit.

Also fixes a compiler warning and removes the ignored error codes.