### PR TITLE
feat: run duplicate pre-hooks just once

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -44,30 +44,7 @@ abstract contract AccountLoupe is IAccountLoupe {
 
     /// @inheritdoc IAccountLoupe
     function getExecutionHooks(bytes4 selector) external view returns (ExecutionHooks[] memory execHooks) {
-        execHooks = _getHooks(getAccountStorage().selectorData[selector].executionHooks);
-    }
-
-    /// @inheritdoc IAccountLoupe
-    function getPreValidationHooks(bytes4 selector)
-        external
-        view
-        returns (
-            FunctionReference[] memory preUserOpValidationHooks,
-            FunctionReference[] memory preRuntimeValidationHooks
-        )
-    {
-        preUserOpValidationHooks =
-            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preUserOpValidationHooks);
-        preRuntimeValidationHooks =
-            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preRuntimeValidationHooks);
-    }
-
-    /// @inheritdoc IAccountLoupe
-    function getInstalledPlugins() external view returns (address[] memory pluginAddresses) {
-        pluginAddresses = getAccountStorage().plugins.values();
-    }
-
-    function _getHooks(HookGroup storage hooks) internal view returns (ExecutionHooks[] memory execHooks) {
+        HookGroup storage hooks = getAccountStorage().selectorData[selector].executionHooks;
         uint256 preExecHooksLength = hooks.preHooks.length();
         uint256 postOnlyExecHooksLength = hooks.postOnlyHooks.length();
         uint256 maxExecHooksLength = postOnlyExecHooksLength;
@@ -128,5 +105,25 @@ abstract contract AccountLoupe is IAccountLoupe {
         assembly ("memory-safe") {
             mstore(execHooks, actualExecHooksLength)
         }
+    }
+
+    /// @inheritdoc IAccountLoupe
+    function getPreValidationHooks(bytes4 selector)
+        external
+        view
+        returns (
+            FunctionReference[] memory preUserOpValidationHooks,
+            FunctionReference[] memory preRuntimeValidationHooks
+        )
+    {
+        preUserOpValidationHooks =
+            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preUserOpValidationHooks);
+        preRuntimeValidationHooks =
+            toFunctionReferenceArray(getAccountStorage().selectorData[selector].preRuntimeValidationHooks);
+    }
+
+    /// @inheritdoc IAccountLoupe
+    function getInstalledPlugins() external view returns (address[] memory pluginAddresses) {
+        pluginAddresses = getAccountStorage().plugins.values();
     }
 }


### PR DESCRIPTION
With https://github.com/erc6900/reference-implementation/pull/29, which removes the ability for plugins to depend on other plugin's hooks, the only cases where there will be duplicate hooks applied to a selector are:
1. When a plugin's manifest incorrectly applies the same pre-hook twice to a selector.
2. When different plugins apply `ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY` to the same selector.

This makes running duplicate pre-hooks multiple times unnecessary.

Note that duplicate post-hooks may still run multiple times if they are attached to different pre-hooks, since the pre-hook return data that are passed to them may be different. And since they will be configured from the same plugin, any duplicate runs will be intentional.

---

Edit: to expand, in cases where a plugin might want to apply `{preHook: A, postHook: B}` and `{preHook: A: postHook: C}` to a selector, AND they want `A` to be executed twice and not once, this can be addressed by collapsing the logic in `B` and `C` into a single post-hook.