### PR TITLE
fix: consistency in comments in IPluginExecutor interface and spec

### DIFF
--- a/standard/ERCs/erc-6900.md
+++ b/standard/ERCs/erc-6900.md
@@ -187,16 +187,18 @@ This prevents accidental misconfiguration or misuse of plugins (both installed a
 ```solidity
 interface IPluginExecutor {
     /// @notice Execute a call from a plugin to another plugin, via an execution function installed on the account.
-    /// @dev Permissions must be granted to the calling plugin for the call to go through.
-    /// @param data Calldata to send to the plugin.
+    /// @dev Plugins are not allowed to call native functions on the account. Permissions must be granted to the
+    /// calling plugin for the call to go through.
+    /// @param data The calldata to send to the plugin.
     /// @return The return data from the call.
     function executeFromPlugin(bytes calldata data) external payable returns (bytes memory);
 
     /// @notice Execute a call from a plugin to a non-plugin address.
-    /// @dev Permissions must be granted to the calling plugin for the call to go through.
-    /// @param target Address of the target to call.
-    /// @param value Value to send with the call.
-    /// @param data Calldata to send to the target.
+    /// @dev If the target is a plugin, the call SHOULD revert. Permissions must be granted to the calling plugin
+    /// for the call to go through.
+    /// @param target The address to be called.
+    /// @param value The value to send with the call.
+    /// @param data The calldata to send to the target.
     /// @return The return data from the call.
     function executeFromPluginExternal(address target, uint256 value, bytes calldata data)
         external


### PR DESCRIPTION
Syncing up the comments from IPluginExecutor.sol from the reference implementation to the standard's description of it.